### PR TITLE
Fix tests with Cabal v2 commands

### DIFF
--- a/hhp.cabal
+++ b/hhp.cabal
@@ -123,6 +123,7 @@ Test-Suite spec
   Hs-Source-Dirs:       test, lib
   GHC-Options:          -Wall
   Type:                 exitcode-stdio-1.0
+  Build-Tool-Depends:   hspec-discover:hspec-discover
   Other-Modules:        Dir
                         Spec
                         BrowseSpec

--- a/hhp.cabal
+++ b/hhp.cabal
@@ -124,6 +124,7 @@ Test-Suite spec
   GHC-Options:          -Wall
   Type:                 exitcode-stdio-1.0
   Build-Tool-Depends:   hspec-discover:hspec-discover
+                      , hhp:hhpc
   Other-Modules:        Dir
                         Spec
                         BrowseSpec

--- a/test/InfoSpec.hs
+++ b/test/InfoSpec.hs
@@ -1,9 +1,7 @@
 module InfoSpec where
 
 import Data.List (isPrefixOf)
-import System.Environment (getExecutablePath)
 import System.Exit
-import System.FilePath
 import System.Process
 import Test.Hspec
 
@@ -53,9 +51,5 @@ spec = do
                 res `shouldSatisfy` ("bar :: [Char]" `isPrefixOf`)
 
         it "doesn't fail on unicode output" $ do
-            dir <- getDistDir
-            code <- rawSystem (dir </> "build/hhpc/hhpc") ["info", "test/data/Unicode.hs", "unicode"]
+            code <- rawSystem "hhpc" ["info", "test/data/Unicode.hs", "unicode"]
             code `shouldSatisfy` (== ExitSuccess)
-
-getDistDir :: IO FilePath
-getDistDir = takeDirectory . takeDirectory . takeDirectory <$> getExecutablePath


### PR DESCRIPTION
This fixes the test suite with `cabal v2-test` by
- Explicitly declaring the dependency on `hspec-discover`, and
- Removing the hard-coded assumptions about the structure of `dist/`.