### PR TITLE
Update to handle sub-libraries in .cabal file.

### DIFF
--- a/lib/Hhp/CabalApi.hs
+++ b/lib/Hhp/CabalApi.hs
@@ -174,9 +174,14 @@ cabalCppOptions dir = do
 
 -- | Extracting all 'BuildInfo' for libraries, executables, and tests.
 cabalAllBuildInfo :: PackageDescription -> [BuildInfo]
-cabalAllBuildInfo pd = libBI ++ execBI ++ testBI ++ benchBI
+cabalAllBuildInfo pd = libBI ++ subBI ++ execBI ++ testBI ++ benchBI
   where
     libBI   = map P.libBuildInfo       $ maybeToList $ P.library pd
+#if MIN_VERSION_Cabal(2,0,0)
+    subBI   = map P.libBuildInfo       $ P.subLibraries pd
+#else
+    subBI   = []
+#endif
     execBI  = map P.buildInfo          $ P.executables pd
     testBI  = map P.testBuildInfo      $ P.testSuites pd
 #if __GLASGOW_HASKELL__ >= 704

--- a/test/CabalApiSpec.hs
+++ b/test/CabalApiSpec.hs
@@ -57,6 +57,11 @@ spec = do
             dirs <- cabalSourceDirs . cabalAllBuildInfo <$> parseCabalFile "test/data/cabalapi.cabal"
             dirs `shouldBe` [".", "test"]
 
+    describe "cabal-subLibraries" $ do
+        it "dependent packages with sublib" $ do
+            pkgs <- cabalDependPackages . cabalAllBuildInfo <$> parseCabalFile "test/data/check-sublib/check-sublib.cabal"
+            pkgs `shouldBe` ["array", "base", "bytestring"]
+
 {-
     describe "cabalAllBuildInfo" $ do
         it "extracts build info" $ do

--- a/test/data/check-sublib/check-sublib.cabal
+++ b/test/data/check-sublib/check-sublib.cabal
@@ -1,0 +1,11 @@
+Name:                   check-sublib
+Version:                0.0.0
+
+library
+  build-depends:       base <5
+
+library foo
+  build-depends:       array
+
+library bar
+  build-depends:       bytestring


### PR DESCRIPTION
This change is to pick up the sub-library entry in the .cabal file.
An example has been implemented in the test.