### PR TITLE
Update to handle sub-libraries in .cabal file for ghc9.

### DIFF
--- a/lib/Hhp/CabalApi.hs
+++ b/lib/Hhp/CabalApi.hs
@@ -142,9 +142,10 @@ cabalCppOptions dir = do
 
 -- | Extracting all 'BuildInfo' for libraries, executables, and tests.
 cabalAllBuildInfo :: PackageDescription -> [BuildInfo]
-cabalAllBuildInfo pd = libBI ++ execBI ++ testBI ++ benchBI
+cabalAllBuildInfo pd = libBI ++ subBI ++ execBI ++ testBI ++ benchBI
   where
     libBI   = map P.libBuildInfo       $ maybeToList $ P.library pd
+    subBI   = map P.libBuildInfo       $ P.subLibraries pd
     execBI  = map P.buildInfo          $ P.executables pd
     testBI  = map P.testBuildInfo      $ P.testSuites pd
     benchBI = map P.benchmarkBuildInfo $ P.benchmarks pd

--- a/test/CabalApiSpec.hs
+++ b/test/CabalApiSpec.hs
@@ -56,6 +56,11 @@ spec = do
             dirs <- cabalSourceDirs . cabalAllBuildInfo <$> parseCabalFile "test/data/cabalapi.cabal"
             dirs `shouldBe` [".", "test"]
 
+    describe "cabal-subLibraries" $ do
+        it "dependent packages with sublib" $ do
+            pkgs <- cabalDependPackages . cabalAllBuildInfo <$> parseCabalFile "test/data/check-sublib/check-sublib.cabal"
+            pkgs `shouldBe` ["array", "base", "bytestring"]
+
 {-
     describe "cabalAllBuildInfo" $ do
         it "extracts build info" $ do

--- a/test/data/check-sublib/check-sublib.cabal
+++ b/test/data/check-sublib/check-sublib.cabal
@@ -1,0 +1,11 @@
+Name:                   check-sublib
+Version:                0.0.0
+
+library
+  build-depends:       base <5
+
+library foo
+  build-depends:       array
+
+library bar
+  build-depends:       bytestring


### PR DESCRIPTION
 Update to pick up sub-library for ghc9.  
ref #14